### PR TITLE
Small changes for Oracle XE (Express-Edition)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -343,7 +343,7 @@ See the type documentation for all parameters.
 
 ```sh
 $ puppet describe ora_database
-``
+```
 
 ##Limitations
 

--- a/lib/ora_utils/ora_tab.rb
+++ b/lib/ora_utils/ora_tab.rb
@@ -91,7 +91,7 @@ module OraUtils
 
 	  def running_database_sids
 	  	database_sids.select do |sid|
-	  		`pgrep -f ^ora_pmon_#{sid}$` != ''
+	  		`pgrep -f "^(ora|xe)_pmon_#{sid}$"` != ''
 	  	end
 	  end
 

--- a/lib/ora_utils/oracle_access.rb
+++ b/lib/ora_utils/oracle_access.rb
@@ -39,6 +39,7 @@ module OraUtils
       results = []
       oratab = OraTab.new
       oratab.running_database_sids.each do |sid|
+        Puppet.debug "executing #{command} on #{sid}"
         results = results + sql(command, {:sid => sid}.merge(parameters))
       end
       results


### PR DESCRIPTION
Hi Bert.

I tried your oracle module with Oracle XE and got some problems with this environment. All I wanted to do is, to add a user to a freshly installed Oracle XE. This worked once, but starting from the second run it fails, because Puppet always tried to add the resource as new. 

After enabling trace and debug, I tried to find out, what happens and was a bit confused, because I didn't found any hints in the log file, that Puppet tries to find out, what users are already in the DB. And further, no error about this. After an afternoon reviews and understanding your code, I added some additional debug messages and found out, that the Class OraTab did not resolve any SIDs as running database SIDs. After evaluating this code and compare this to with my environment, the fix was easy. 

You use `pgrep` to check if there is a process running which name is `ora_pmon_{SID}`. Unfortunately Oracle renamed this process in the express edition and it seems, the are named `xe_pmon_{SID}' here. After modifying the regex to match both names, all worked well. 

I'm not sure if there can be an automated unit test for this fix. At least, my Puppet and Ruby knowledge is not well enough to supply a test for it. Even when in my "home" environment (Java, Groovy) I would never accept a fix without a test...

Maybe you can give me some hints or advices for the future, how to do automatic tests... :-)

I also fixed a missing backtick on the Readme file.

Best regards
 Andreas  