### PR TITLE
gh-43 - asm_facts fail on windows

### DIFF
--- a/lib/facter/asm_facts.rb
+++ b/lib/facter/asm_facts.rb
@@ -2,8 +2,12 @@ $:.unshift(Pathname.new(__FILE__).parent.parent.parent.parent + 'easy_type/lib')
 $:.unshift(Pathname.new(__FILE__).parent.parent)
 require 'facter'
 require 'puppet'
-require 'puppet/type/ora_asm_diskgroup'
-require 'puppet/type/ora_asm_volume'
+begin
+  require 'puppet/type/ora_asm_diskgroup'
+  require 'puppet/type/ora_asm_volume'
+rescue
+
+end
 
 Facter.add("ora_asm_diskgroups") do
   setcode do


### PR DESCRIPTION
   * previously when running puppet agent runs, puppet syncs all the facts,
     providers and types that could be used on the system.
     Unfornately the asm_facts fact fails to load properely on windows
     because it is an unsupported os.  This causes catalog compilation
     to fail.  This fix here just fails the loading of the fact more
     gracefully and allows catalog compilation to complete.